### PR TITLE
Testing: mocked and memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ addons:
   sonarcloud:
     organization: "discipl" # the key of the org you chose at step #3
 script:
+  - npm test
   # other script steps might be done before running the actual analysis
   - sonar-scanner

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ addons:
 script:
   - npm test
   # other script steps might be done before running the actual analysis
-  - sonar-scanner
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner; fi'

--- a/package-lock.json
+++ b/package-lock.json
@@ -762,6 +762,35 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "^2 || ^3"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+      "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -770,6 +799,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -1093,6 +1128,12 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "js-levenshtein": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
@@ -1120,6 +1161,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -1134,6 +1181,18 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
       "dev": true
     },
     "loose-envify": {
@@ -1221,6 +1280,27 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nise": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
+      }
+    },
     "node-modules-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
@@ -1304,6 +1384,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -1423,6 +1512,21 @@
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
     },
+    "sinon": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.2.tgz",
+      "integrity": "sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.2.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.2",
+        "diff": "^3.5.0",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.7",
+        "supports-color": "^5.5.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1455,6 +1559,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "chai": "^4.2.0",
     "discipl-core-memory": "git+https://github.com/discipl/discipl-core-memory.git",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "sinon": "^7.2.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const initializeConnector = async (connector) => {
   if(!Object.keys(disciplCoreConnectors).includes(connector)) {
     import(CONNECTOR_MODULE_PREFIX+connector).then(module => {
         let connectorModuleClass = module.default
-        disciplCoreConnectors[connector] = new connectorModuleClass()
+        registerConnector(connector, new connectorModuleClass())
     })
   }
 }
@@ -31,6 +31,16 @@ const initializeConnector = async (connector) => {
 const getConnector = async (connector) => {
   await initializeConnector(connector)
   return disciplCoreConnectors[connector]
+}
+
+/**
+ * Registers a connector explicitly.
+ *
+ * @param name of the connector. Packages containing a connector follow the naming convention CONNECTOR_MODULE_PREFIX + name
+ * @param connector instantiated object representing the connector
+ */
+const registerConnector = (name, connector) => {
+  disciplCoreConnectors[name] = connector;
 }
 
 /**
@@ -268,6 +278,7 @@ const revoke = async (ssid, link) => {
 
 export {
   getConnector,
+  registerConnector,
   newSsid,
   claim,
   attest,

--- a/src/index.js
+++ b/src/index.js
@@ -18,10 +18,9 @@ var disciplCoreConnectors = []
  */
 const initializeConnector = async (connector) => {
   if(!Object.keys(disciplCoreConnectors).includes(connector)) {
-    import(CONNECTOR_MODULE_PREFIX+connector).then(module => {
-        let connectorModuleClass = module.default
-        registerConnector(connector, new connectorModuleClass())
-    })
+    let module = await import(CONNECTOR_MODULE_PREFIX+connector);
+    let connectorModuleClass = module.default
+    registerConnector(connector, new connectorModuleClass())
   }
 }
 
@@ -243,13 +242,13 @@ const exportLD = async (SsidDidOrLink, maxdepth = 3, ssid = null, visitedStack =
 
   let res = await get(currentLink, ssid)
   if(res != null) {
-    data = res.data
+    let data = res.data
     if(res.previous && (SsidDidOrLink.indexOf(DID_PREFIX) == 0)) {
       console.log('Get previous of channel'+res.previous)
       exportData[currentSsid.did] = await exportLD(res.previous, maxdepth, ssid, visitedStack)
     }
     exportData[currentSsid.did][currentLink] = {}
-    for(elem in data) {
+    for(let elem in data) {
       exportData[currentSsid.did][currentLink][elem] = {}
       let value = data[elem]
       try {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,18 +1,21 @@
-import { expect } from "chai";
+import { expect, use } from "chai";
 import * as discipl from '../src/index.js';
 
+import sinon from 'sinon';
+
 describe("desciple-core-api", () => {
-    describe("The disciple core API", () => {
-        it("should be able to get the memory connector asynchronously", async () => {
+    describe("The disciple core API with memory connector", () => {
+
+        it("should be able to get the connector asynchronously", async () => {
             const connector = await discipl.getConnector("memory")
             expect(connector.getName()).to.equal("memory")
-            
+
             expect(connector.getName(), "when loaded for the second time").to.equal("memory")
         })
 
         it("should be able to retrieve a new ssid asynchronously", async () => {
             let ssid = await discipl.newSsid('memory')
-            
+
             expect(ssid.pubkey).to.be.a('string')
             expect(ssid.pubkey.length).to.equal(88)
             expect(ssid.privkey).to.be.a('string')
@@ -22,15 +25,70 @@ describe("desciple-core-api", () => {
             expect(ssid.connector.getName()).to.equal('memory')
         })
 
-
         it("should be able to add a first claim to some new channel through a claim() method", async () => {
             let ssid = await discipl.newSsid('memory')
-            let claimlink = await discipl.claim(tmpSsid, {'need':'beer'})
+            let claimlink = await discipl.claim(ssid, {'need': 'beer'})
 
             expect(claimlink).to.be.a('string')
             expect(claimlink.length).to.equal(108)
         })
+    },
+    describe("The disciple core API with mocked connector", () => {
+
+        it("should be able to retrieve a new mocked ssid asynchronously", async () => {
+            let newSsidStub = sinon.stub().returns({pubkey: "".padStart(88,"1"), privkey: "".padStart(88,"2")})
+            let getNameStub = sinon.stub().returns("mock")
+            let stubConnector = {newSsid: newSsidStub, getName: getNameStub};
+
+
+            await discipl.registerConnector('mock', stubConnector)
+            let ssid = await discipl.newSsid('mock')
+
+            expect(newSsidStub.calledOnce).to.equal(true)
+            expect(getNameStub.calledOnce).to.equal(true)
+
+            expect(ssid.pubkey).to.equal("".padStart(88,"1"))
+            expect(ssid.privkey).to.equal("".padStart(88, "2"))
+            expect(ssid.did).to.equal('did:discipl:mock:' + "".padStart(88,"1"))
+            expect(ssid.connector.getName()).to.equal('mock')
+        })
+
+        it("should be able to add a claim to some new channel through a claim() method through a mocked connector", async () => {
+            let ssid = {did: 'did:discipl:mock:111'}
+            let claimStub = sinon.stub().returns("claimRef");
+            let getNameStub = sinon.stub().returns("mock")
+            let stubConnector = {claim: claimStub, getName: getNameStub};
+
+
+            await discipl.registerConnector('mock', stubConnector)
+            let claimlink = await discipl.claim(ssid, {'need':'beer'})
+
+            expect(claimStub.calledOnceWith({did: 'did:discipl:mock:111', connector: stubConnector, pubkey: '111'}, {'need':'beer'})).to.equal(true)
+            expect(getNameStub.calledOnce).to.be.equal(true)
+
+
+            expect(claimlink).to.equal('link:discipl:mock:claimRef')
+        })
+
+        it("should be able to add a claim to some new channel through a claim() method with an object as reference", async () => {
+            let ssid = {did: 'did:discipl:mock:111'}
+            let claimStub = sinon.stub().returns({someKey:"infoNeededByConnector"});
+            let getNameStub = sinon.stub().returns("mock")
+            let stubConnector = {claim: claimStub, getName: getNameStub};
+
+
+            await discipl.registerConnector('mock', stubConnector)
+            let claimlink = await discipl.claim(ssid, {'need':'beer'})
+
+            expect(claimStub.calledOnceWith({did: 'did:discipl:mock:111', connector: stubConnector, pubkey: '111'}, {'need':'beer'})).to.equal(true)
+            expect(getNameStub.calledOnce).to.be.equal(true)
+
+            expect(claimlink).to.equal('link:discipl:mock:jdkIBFi8PojrrOV/Z9qtuS+8hDyUUMUkono9Rof4ZxlA6OIQjOWcHeSWGD73fn2I')
+        })
+
+
     })
+    )
 })
 
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -13,15 +13,22 @@ describe("desciple-core-api", () => {
         it("should be able to retrieve a new ssid asynchronously", async () => {
             let ssid = await discipl.newSsid('memory')
             
-            it("which should contain a large random public key, private key and connector object", () => {
-                expect(ssid.pubkey).to.be.a('string')
-                expect(ssid.pubkey.length).to.equal(88)
-                expect(ssid.privkey).to.be.a('string')
-                expect(ssid.privkey.length).to.equal(88)
-                expect(ssid.pubkey).to.not.equal(ssid.privkey)
-                expect(ssid.did).to.equal('did:discipl:memory:' + ssid.pubkey)
-                expect(ssid.connector.getName()).to.equal('memory')
-            })
+            expect(ssid.pubkey).to.be.a('string')
+            expect(ssid.pubkey.length).to.equal(88)
+            expect(ssid.privkey).to.be.a('string')
+            expect(ssid.privkey.length).to.equal(88)
+            expect(ssid.pubkey).to.not.equal(ssid.privkey)
+            expect(ssid.did).to.equal('did:discipl:memory:' + ssid.pubkey)
+            expect(ssid.connector.getName()).to.equal('memory')
+        })
+
+
+        it("should be able to add a first claim to some new channel through a claim() method", async () => {
+            let ssid = await discipl.newSsid('memory')
+            let claimlink = await discipl.claim(tmpSsid, {'need':'beer'})
+
+            expect(claimlink).to.be.a('string')
+            expect(claimlink.length).to.equal(108)
         })
     })
 })

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,11 +1,29 @@
 import { expect } from "chai";
 import * as discipl from '../src/index.js';
 
-describe("index test", () => {
-    describe("getConnector function", () => {
-        it("should be able to get the memory connector", async () => {
-            const connector = await discipl.getConnector("memory");
-            expect(connector.getName(), "memory")
+describe("desciple-core-api", () => {
+    describe("The disciple core API", () => {
+        it("should be able to get the memory connector asynchronously", async () => {
+            const connector = await discipl.getConnector("memory")
+            expect(connector.getName()).to.equal("memory")
+            
+            expect(connector.getName(), "when loaded for the second time").to.equal("memory")
+        })
+
+        it("should be able to retrieve a new ssid asynchronously", async () => {
+            let ssid = await discipl.newSsid('memory')
+            
+            it("which should contain a large random public key, private key and connector object", () => {
+                expect(ssid.pubkey).to.be.a('string')
+                expect(ssid.pubkey.length).to.equal(88)
+                expect(ssid.privkey).to.be.a('string')
+                expect(ssid.privkey.length).to.equal(88)
+                expect(ssid.pubkey).to.not.equal(ssid.privkey)
+                expect(ssid.did).to.equal('did:discipl:memory:' + ssid.pubkey)
+                expect(ssid.connector.getName()).to.equal('memory')
+            })
         })
     })
 })
+
+

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -69,6 +69,7 @@ describe("desciple-core-api", () => {
 
             let verifiedAttestor = await discipl.verify('agree', claimlink2, [ssid, null, {'did':'did:discipl:memory:1234'}, attestorSsid])
 
+            // The first ssid that is valid and proves the attestation should be returned
             expect(verifiedAttestor).to.equal(attestorSsid)
         })
 
@@ -183,6 +184,7 @@ describe("desciple-core-api", () => {
             let verifyStub = sinon.stub()
 
             verifyStub.onCall(0).returns('attestationRef')
+            // No revocations will be found
             verifyStub.onCall(1).returns(null)
             verifyStub.onCall(2).returns(null)
 
@@ -234,7 +236,9 @@ describe("desciple-core-api", () => {
             let verifyStub = sinon.stub()
 
             verifyStub.onCall(0).returns('attestationRef')
+            // A revocation of the attestation will be found
             verifyStub.onCall(1).returns('attestationRevocationRef')
+            // No revocations of the revocation of the attestation will be found
             verifyStub.onCall(2).returns(null)
             verifyStub.onCall(3).returns(null)
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import {expect} from "chai";
 import * as discipl from '../src/index.js';
 
 import sinon from 'sinon';
@@ -70,6 +70,20 @@ describe("desciple-core-api", () => {
             let verifiedAttestor = await discipl.verify('agree', claimlink2, [ssid, null, {'did':'did:discipl:memory:1234'}, attestorSsid])
 
             expect(verifiedAttestor).to.equal(attestorSsid)
+        })
+
+        it("should be able to export linked verifiable claim channels", async () => {
+            let ssid = await discipl.newSsid('memory')
+            let claimlink1 = await discipl.claim(ssid, {'need': 'beer'})
+            let claimlink2 = await discipl.claim(ssid, {'need': 'wine'})
+
+            let attestorSsid = await discipl.newSsid('memory')
+
+            let attestationLink = await discipl.attest(attestorSsid, 'agree', claimlink2);
+            let exportedData = await discipl.exportLD(attestorSsid)
+
+
+            expect(exportedData[attestorSsid.did][attestationLink]['agree'][ssid.did][claimlink2]).to.deep.equal({'need': 'wine'})
         })
     },
     describe("The disciple core API with mocked connector", () => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -45,7 +45,7 @@ describe("desciple-core-api", () => {
 
         it("should be able to attest to a second claim in a chain", async () => {
             let ssid = await discipl.newSsid('memory')
-            let claimlink1 = await discipl.claim(ssid, {'need': 'beer'})
+            await discipl.claim(ssid, {'need': 'beer'})
             let claimlink2 = await discipl.claim(ssid, {'need': 'wine'})
 
             let attestorSsid = await discipl.newSsid('memory')
@@ -60,12 +60,12 @@ describe("desciple-core-api", () => {
 
         it("should be able to verify an attestation", async () => {
             let ssid = await discipl.newSsid('memory')
-            let claimlink1 = await discipl.claim(ssid, {'need': 'beer'})
+            await discipl.claim(ssid, {'need': 'beer'})
             let claimlink2 = await discipl.claim(ssid, {'need': 'wine'})
 
             let attestorSsid = await discipl.newSsid('memory')
 
-            let attestationLink = await discipl.attest(attestorSsid, 'agree', claimlink2);
+            await discipl.attest(attestorSsid, 'agree', claimlink2);
 
             let verifiedAttestor = await discipl.verify('agree', claimlink2, [ssid, null, {'did':'did:discipl:memory:1234'}, attestorSsid])
 
@@ -74,7 +74,7 @@ describe("desciple-core-api", () => {
 
         it("should be able to export linked verifiable claim channels", async () => {
             let ssid = await discipl.newSsid('memory')
-            let claimlink1 = await discipl.claim(ssid, {'need': 'beer'})
+            await discipl.claim(ssid, {'need': 'beer'})
             let claimlink2 = await discipl.claim(ssid, {'need': 'wine'})
 
             let attestorSsid = await discipl.newSsid('memory')


### PR DESCRIPTION
This PR continues #13.

I'm splitting the tests in two categories:

- Unit tests, which mock the connector and verify that correct calls have been 
- Integration tests, which use the memory connector to test scenarios

No state is carried over between tests.