### PR TITLE
fix issue #15, infinite recursion at verifying attestation of a revok…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,7 @@ const attest = async (ssid, predicate, link) => {
  * If none of the given ssid's have attested, the method returns null
  */
 const verify = async (predicate, link, ssids, all = false) => {
+  debugger
   let result = []
   for (let i in ssids) {
     let ssid = ssids[i]
@@ -151,7 +152,7 @@ const verify = async (predicate, link, ssids, all = false) => {
     let reference = await ssid.connector.verify(ssid, attestation)
     if (reference) {
       if (await verify(REVOKE_PREDICATE, getLink(ssid, reference), [ssid]) == null) {
-        if (await verify(REVOKE_PREDICATE, link, [await getSsidOfLinkedClaim(link)]) == null) {
+        if (predicate == REVOKE_PREDICATE || await verify(REVOKE_PREDICATE, link, [await getSsidOfLinkedClaim(link)]) == null) {
           if (all) {
             result.push(ssid)
           } else {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -73,6 +73,22 @@ describe('desciple-core-api', () => {
       expect(verifiedAttestor).to.equal(attestorSsid)
     })
 
+    it('should be able to not verify an attestation of a revoked claim', async () => {
+      let ssid = await discipl.newSsid('memory')
+      await discipl.claim(ssid, { 'need': 'beer' })
+      let claimlink2 = await discipl.claim(ssid, { 'need': 'wine' })
+
+      let attestorSsid = await discipl.newSsid('memory')
+
+      await discipl.attest(attestorSsid, 'agree', claimlink2)
+      await discipl.revoke(ssid, claimlink2)
+
+      let verifiedAttestor = await discipl.verify('agree', claimlink2, [ssid, null, { 'did': 'did:discipl:memory:1234' }, attestorSsid])
+
+      // The first ssid that is valid and proves the attestation should be returned
+      expect(verifiedAttestor).to.equal(null)
+    })
+
     it('should be able to export linked verifiable claim channels', async () => {
       let ssid = await discipl.newSsid('memory')
       await discipl.claim(ssid, { 'need': 'beer' })
@@ -234,7 +250,7 @@ describe('desciple-core-api', () => {
       verifyStub.onCall(1).returns('attestationRevocationRef')
       // No revocations of the revocation of the attestation will be found
       verifyStub.onCall(2).returns(null)
-      verifyStub.onCall(3).returns(null)
+      //verifyStub.onCall(3).returns(null)
 
       let getSsidOfClaimStub = sinon.stub().returns({ pubkey: 'attestor' })
 
@@ -246,16 +262,16 @@ describe('desciple-core-api', () => {
 
       let verifiedAttestor = await discipl.verify('agree', claimlink, [attestorSsid])
 
-      expect(verifyStub.callCount).to.equal(4)
+      expect(verifyStub.callCount).to.equal(3)
       expect(verifyStub.args[0]).to.deep.equal([{ did: 'did:discipl:mock:attestor', connector: stubConnector, pubkey: 'attestor' }, { agree: claimlink }])
       expect(verifyStub.args[1]).to.deep.equal([{ did: 'did:discipl:mock:attestor', connector: stubConnector, pubkey: 'attestor' }, { revoke: attestationlink }])
       expect(verifyStub.args[2]).to.deep.equal([{ did: 'did:discipl:mock:attestor', connector: stubConnector, pubkey: 'attestor' }, { revoke: attestationrevocationlink }])
-      expect(verifyStub.args[3]).to.deep.equal([{ did: 'did:discipl:mock:attestor', connector: stubConnector, pubkey: 'attestor' }, { revoke: attestationlink }])
+      //expect(verifyStub.args[3]).to.deep.equal([{ did: 'did:discipl:mock:attestor', connector: stubConnector, pubkey: 'attestor' }, { revoke: attestationlink }])
 
-      expect(getSsidOfClaimStub.calledOnce).to.equal(true)
-      expect(getSsidOfClaimStub.args[0]).to.deep.equal(['attestationRef'])
+      expect(getSsidOfClaimStub.calledOnce).to.equal(false)
+      //expect(getSsidOfClaimStub.args[0]).to.deep.equal(['attestationRef'])
 
-      expect(getNameStub.callCount).to.equal(3)
+      expect(getNameStub.callCount).to.equal(2)
 
       expect(verifiedAttestor).to.equal(null)
     })


### PR DESCRIPTION
The implementation of verify() already checks for revocations of revocations and so on in the first (recursive) call to verify(). And as intended, yes it additionally checks for revocation of the original claim too through a second recursive call. The latter should not be done however when the verify method was called to check for revocations as that results in a infinite loop as you encountered. 

Changes in this PR fixes this. Added an extra test to test the case of verifying attestation of a revoked claim. Had to change the last test with the mocks too, but that test probably needs some work to test a littlebit more.