### PR TITLE
Observe Result as a class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Discipl Core API",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ const allow = async (ssid, scope = null, did = null) => {
     allowConfiguration['did'] = did
   }
 
-  claim(ssid, { [BaseConnector.ALLOW]: allowConfiguration })
+  await claim(ssid, { [BaseConnector.ALLOW]: allowConfiguration })
 }
 
 /**

--- a/src/observe-result.js
+++ b/src/observe-result.js
@@ -1,0 +1,27 @@
+import { take, toArray } from 'rxjs/operators'
+
+class ObserveResult {
+  constructor (observable, readyPromise) {
+    this._observable = observable
+    this._readyPromise = readyPromise
+  }
+
+  async takeOne () {
+    let resultPromise = this._observable.pipe(take(1)).toPromise()
+    await this._readyPromise
+    return resultPromise
+  }
+
+  async take (amount) {
+    let resultPromise = this._observable.pipe(take(amount)).pipe(toArray()).toPromise()
+    await this._readyPromise
+    return resultPromise
+  }
+
+  async subscribe (subscriber) {
+    this._observable.subscribe(subscriber)
+    await this._readyPromise
+  }
+}
+
+export default ObserveResult

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -368,22 +368,48 @@ describe('discipl-core', () => {
 
       expect(claimlink).to.equal('link:discipl:mock:claimRef')
     })
-    /*
-    it('should be able to add a claim to some new channel through a claim() method with an object as reference', async () => {
-      let ssid = { did: 'did:discipl:mock:111' }
-      let claimStub = sinon.stub().returns({ someKey: 'infoNeededByConnector' })
-      let getNameStub = sinon.stub().returns('mock')
-      let stubConnector = { claim: claimStub, getName: getNameStub }
+
+    it('should be able to do an allow claim with a scope', async () => {
+      let ssid = { did: 'did:discipl:mock:111', privkey: 'SECRET_KEY' }
+      let claimStub = sinon.stub().returns('link:discipl:mock:claimRef')
+
+      let stubConnector = { claim: claimStub }
+
+      await discipl.registerConnector('mock', stubConnector)
+      await discipl.allow(ssid, 'link:discipl:abcabc')
+
+      expect(claimStub.callCount).to.equal(1)
+      expect(claimStub.args[0]).to.deep.equal(['did:discipl:mock:111', 'SECRET_KEY', { 'DISCIPL_ALLOW': { 'scope': 'link:discipl:abcabc' } }])
+    })
+
+    it('should be able to do an allow claim with a did', async () => {
+      let ssid = { did: 'did:discipl:mock:111', privkey: 'SECRET_KEY' }
+      let claimStub = sinon.stub().returns('link:discipl:mock:claimRef')
+
+      let stubConnector = { claim: claimStub }
+
+      await discipl.registerConnector('mock', stubConnector)
+      await discipl.allow(ssid, null, 'did:discipl:mock:222')
+
+      expect(claimStub.callCount).to.equal(1)
+      expect(claimStub.args[0]).to.deep.equal(['did:discipl:mock:111', 'SECRET_KEY', { 'DISCIPL_ALLOW': { 'did': 'did:discipl:mock:222' } }])
+    })
+
+    it('should be able to add a claim to some new channel through a claim() method through a mocked connector', async () => {
+      let ssid = { did: 'did:discipl:mock:111', privkey: 'SECRET_KEY' }
+      let claimStub = sinon.stub().returns('link:discipl:mock:claimRef')
+
+      let stubConnector = { claim: claimStub }
 
       await discipl.registerConnector('mock', stubConnector)
       let claimlink = await discipl.claim(ssid, { 'need': 'beer' })
 
-      expect(claimStub.calledOnceWith({ did: 'did:discipl:mock:111', connector: stubConnector, pubkey: '111' }, { 'need': 'beer' })).to.equal(true)
-      expect(getNameStub.calledOnce).to.equal(true)
+      expect(claimStub.callCount).to.equal(1)
+      expect(claimStub.calledOnceWith('did:discipl:mock:111', 'SECRET_KEY', { 'need': 'beer' })).to.equal(true)
 
-      expect(claimlink).to.equal('link:discipl:mock:jdkIBFi8PojrrOV/Z9qtuS+8hDyUUMUkono9Rof4ZxlA6OIQjOWcHeSWGD73fn2I')
+      expect(claimlink).to.equal('link:discipl:mock:claimRef')
     })
-*/
+
     it('should be able to get a claim added through claims', async () => {
       let claimlink = 'link:discipl:mock:claimRef'
       let prevClaimlink = 'link:discipl:mock:previous'


### PR DESCRIPTION
Introduces the main pathways to allow consumers of core to easily use the observables we create

(Also, fixes an ignored-promise bug with allow)