### PR TITLE
Introducing @discipl/core-baseconnector as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/core",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1154,7 +1154,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@discipl/core-baseconnector/-/core-baseconnector-0.2.1.tgz",
       "integrity": "sha512-4E8kLE/p5FpGVfr1wCvaTeHLO2/aLyLYYb1ieHeg73CeSXVJIQJDhtyVISDfTR/tr9o4LiYVrtpK2BaXHYi8Xw==",
-      "dev": true,
       "requires": {
         "json-stable-stringify": "^1.0.1"
       }
@@ -4023,7 +4022,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
       }
@@ -4046,8 +4044,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsx-ast-utils": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Discipl Core API",
   "main": "dist/index.js",
   "module": "src/index.js",
@@ -22,6 +22,7 @@
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/codecov/bin/codecov"
   },
   "dependencies": {
+    "@discipl/core-baseconnector": "^0.2.1",
     "rxjs": "^6.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We explicitly use the baseconnector through BaseConnector.ALLOW, however
the dependency was not added. This had not shown up before because all
environments had the right dependency indirectly through a connector.